### PR TITLE
[Linux] Remove glBindFrameBuffer call with texture

### DIFF
--- a/Siv3D/src/Siv3D-Platform/OpenGL4/Siv3D/Renderer/GL4/BackBuffer/GL4InternalTexture2D.cpp
+++ b/Siv3D/src/Siv3D-Platform/OpenGL4/Siv3D/Renderer/GL4/BackBuffer/GL4InternalTexture2D.cpp
@@ -91,7 +91,6 @@ namespace s3d
 			::glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
 			::glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 
-			::glBindFramebuffer(GL_FRAMEBUFFER, texture);
 			::glFramebufferTexture(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, texture, 0);
 			if (::glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE)
 			{


### PR DESCRIPTION
## 誤った引数で呼び出されている可能性のある関数呼び出しの削除

`glBindFrameBuffer` でテクスチャをアタッチしようとしているように思われたので削除しています。